### PR TITLE
Fix error with extra_link_args in Python API.

### DIFF
--- a/API/python/setup.py
+++ b/API/python/setup.py
@@ -8,10 +8,11 @@ module1 = Extension("overfeat",
                     libraries = ['TH', 'overfeat', 'openblas'],
                     sources = ['overfeatmodule.cpp'],
                     extra_compile_args=['-fopenmp'],
-                    extra_link_args=['-lgomp', '-l%s'%(path.abspath('../../src/libTH.a'))])
+                    extra_link_args=['-lgomp', '-lTH', '-L%s'%(path.abspath('../../src/libTH.a'))])
 
 setup(name = 'overfeat',
       version = '1.0',
       description = 'Python bindings for overfeat',
       ext_modules = [module1],
       install_requires = ['numpy'])
+


### PR DESCRIPTION
While trying to compile the Python extension, I encountered the same issue as the two people here:
- https://groups.google.com/d/msg/overfeat/nzcWFEdAMD0/OS069TrBhfsJ

Here's a pull request that fixes the problem.  Thanks!
